### PR TITLE
Add ability to import server_cfg.ini/entry_list.ini

### DIFF
--- a/db/mig_1.1.0_1.2.0.sql
+++ b/db/mig_1.1.0_1.2.0.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `configurations`
+ADD COLUMN `start_rule` int(10) NOT NULL AFTER `max_ballast`,
+ADD COLUMN `time_of_day_mult` int(10) NOT NULL AFTER `disable_gas_cut_penality`;

--- a/public/app/pages/configuration.js
+++ b/public/app/pages/configuration.js
@@ -47,6 +47,7 @@ Vue.component('Configuration', {
 			tires_wear_rate: 100,
 			allowed_tires_out: 2,
 			max_ballast: 150,
+			start_rule: 1,
 			disable_gas_cut_penality: false,
 			dynamic_track: true,
 			condition: 'CUSTOM',
@@ -75,6 +76,7 @@ Vue.component('Configuration', {
 			join_type: 1,
 			time: '14:00',
 			sun_angle: 16,
+			time_of_day_mult: 1,
 			track: '',
 			legal_tyres: '',
 			udp_plugin_local_port: 0,
@@ -176,6 +178,7 @@ Vue.component('Configuration', {
 			this.tires_wear_rate = 100;
 			this.allowed_tires_out = 2;
 			this.max_ballast = 150;
+			this.start_rule = 1;
 			this.disable_gas_cut_penality = false;
 			this.dynamic_track = true;
 			this.condition = 'CUSTOM';
@@ -204,6 +207,7 @@ Vue.component('Configuration', {
 			this.join_type = 1;
 			this.time = '14:00';
 			this.sun_angle = 16;
+			this.time_of_day_mult = 1;
 			this.track = '';
 			this.legal_tyres = '';
 			this.udp_plugin_local_port = 0;
@@ -254,6 +258,7 @@ Vue.component('Configuration', {
 				this.tires_wear_rate = resp.data.tires_wear_rate;
 				this.allowed_tires_out = resp.data.allowed_tires_out;
 				this.max_ballast = resp.data.max_ballast;
+				this.start_rule = resp.data.start_rule;
 				this.disable_gas_cut_penality = resp.data.disable_gas_cut_penality;
 				this.result_screen_time = resp.data.result_screen_time;
 				this.dynamic_track = resp.data.dynamic_track;
@@ -282,6 +287,7 @@ Vue.component('Configuration', {
 				this.race_extra_lap = resp.data.race_extra_lap;
 				this.join_type = resp.data.join_type;
 				this.sun_angle = resp.data.sun_angle;
+				this.time_of_day_mult = resp.data.time_of_day_mult;
 				this.time = this.calculateTimeBySunAngle(this.sun_angle);
 				this.legal_tyres = resp.data.legal_tyres;
 				this.udp_plugin_local_port = resp.data.udp_plugin_local_port;
@@ -392,7 +398,9 @@ Vue.component('Configuration', {
 				tires_wear_rate: parseInt(this.tires_wear_rate),
 				allowed_tires_out: parseInt(this.allowed_tires_out),
 				max_ballast: parseInt(this.max_ballast),
+				start_rule: parseInt(this.start_rule),
 				disable_gas_cut_penality: this.disable_gas_cut_penality,
+				time_of_day_mult: parseInt(this.time_of_day_mult),
 				result_screen_time: parseInt(this.result_screen_time),
 				dynamic_track: this.dynamic_track,
 				condition: this.condition,

--- a/public/template/pages/configuration.html
+++ b/public/template/pages/configuration.html
@@ -182,6 +182,14 @@
 							<td><input type="checkbox" name="disable_gas_cut_penality" v-model="disable_gas_cut_penality" /></td>
 						</tr>
 						<tr>
+							<td>Jump Start:</td>
+							<select name="start_rule" v-model="start_rule">
+								<option value="0">Car Locked</option>
+								<option value="1">Teleport To Pit</option>
+								<option value="2">Drive-through</option>
+							</select>
+						</tr>
+						<tr>
 							<td>Legal Tyres:</td>
 							<td><input type="text" name="legal_tyres" v-model="legal_tyres" /></td>
 						</tr>
@@ -349,6 +357,10 @@
 						<tr>
 							<td>Sun angle:</td>
 							<td><input type="number" name="sun_angle" v-model="sun_angle" readonly /></td>
+						</tr>
+						<tr>
+							<td>Multiplier:</td>
+							<td><input type="number" name="time_of_day_mult" v-model="time_of_day_mult" min="1" max="10" step="1" /></td>
 						</tr>
 						<tr>
 							<td colspan="2"><h3>Weather</h3></td>

--- a/public/template/pages/configuration.html
+++ b/public/template/pages/configuration.html
@@ -565,12 +565,35 @@
 			</div>
 		</div>
 
+		<div class="box" v-if="importConfig">
+			<div class="wrapper">
+				<h2>Import Configuration</h2>
+				<p>Please select the following config files in the file upload dialog (you can select multiple files):</p>
+				<p>
+					<i class="fa fa-check-square-o" v-if="tmpSrvCfg !== null"></i>
+					<i class="fa fa-square-o" v-else></i>
+					<code>server_cfg.ini</code>
+					<br/>
+					<i class="fa fa-check-square-o" v-if="tmpEntryListCfg !== null"></i>
+					<i class="fa fa-square-o" v-else></i>
+					<code>entry_list.ini</code>
+				</p>
+
+				<p>
+					<input type="file" multiple @change="importConfigs($event.target.files)">
+				</p>
+
+				<button v-on:click="closeImportConfig()">Cancel</button>
+			</div>
+		</div>
+
 		<div class="box">
 			<div class="wrapper">
 				<msg :type="\'success\'" :msg="\'The configuration has been saved.\'" v-if="saved"></msg>
 				<msg :type="\'success\'" :msg="\'The configuration has been removed.\'" v-if="removed"></msg>
 
 				<button v-on:click="openAddEditConfig(0)">Add Configuration</button>
+				<button v-on:click="openImportConfig()">Import Configuration</button>
 
 				<table>
 					<thead>

--- a/src/instance/config.go
+++ b/src/instance/config.go
@@ -94,8 +94,9 @@ func ServerConfigToIniString(config *model.Configuration) string {
 	ini += "ALLOWED_TYRES_OUT=" + intToStr(config.AllowedTiresOut) + sep
 	ini += "ABS_ALLOWED=" + intToStr(config.ABS) + sep
 	ini += "TC_ALLOWED=" + intToStr(config.TC) + sep
-	ini += "START_RULE=1" + sep
+	ini += "START_RULE=" + intToStr(config.StartRule) + sep
 	ini += "RACE_GAS_PENALTY_DISABLED=" + boolToStr(config.DisableGasCutPenality) + sep
+	ini += "TIME_OF_DAY_MULT=" + intToStr(config.TimeOfDayMult) + sep
 	ini += "RESULT_SCREEN_TIME=" + intToStr(config.ResultScreenTime) + sep
 	ini += "MAX_CONTACTS_PER_KM=" + intToStr(config.MaxCollisionsKm) + sep
 	ini += "STABILITY_ALLOWED=" + boolToStr(config.StabilityAid) + sep

--- a/src/instance/config.go
+++ b/src/instance/config.go
@@ -113,6 +113,13 @@ func ServerConfigToIniString(config *model.Configuration) string {
 	ini += "RACE_EXTRA_LAP=" + boolToStr(config.RaceExtraLap) + sep
 	ini += "WELCOME_MESSAGE=" + config.Welcome + sep
 
+	if config.Booking {
+		ini += sep
+		ini += "[BOOK]" + sep
+		ini += "NAME=Booking" + sep
+		ini += "TIME=" + intToStr(config.BookingTime) + sep
+	}
+
 	if config.Practice {
 		ini += sep
 		ini += "[PRACTICE]" + sep
@@ -165,7 +172,7 @@ func ServerConfigToIniString(config *model.Configuration) string {
 
 	ini += sep
 	ini += "[DATA]" + sep
-	ini += "DESCRIPTION=" + sep
+	ini += "DESCRIPTION=" + config.Description + sep
 	ini += "EXSERVEREXE=" + sep
 	ini += "EXSERVERBAT=" + sep
 	ini += "EXSERVERHIDEWIN=0" + sep

--- a/src/model/configuration.go
+++ b/src/model/configuration.go
@@ -34,7 +34,9 @@ type Configuration struct {
 	TiresWearRate         int    `db:"tires_wear_rate" json:"tires_wear_rate"`
 	AllowedTiresOut       int    `db:"allowed_tires_out" json:"allowed_tires_out"`
 	MaxBallast            int    `db:"max_ballast" json:"max_ballast"`
+	StartRule             int    `db:"start_rule" json:"start_rule"`
 	DisableGasCutPenality bool   `db:"disable_gas_cut_penality" json:"disable_gas_cut_penality"`
+	TimeOfDayMult         int    `db:"time_of_day_mult" json:"time_of_day_mult"`
 	ResultScreenTime      int    `db:"result_screen_time" json:"result_screen_time"`
 	DynamicTrack          bool   `db:"dynamic_track" json:"dynamic_track"`
 	Condition             string `db:"track_condition" json:"condition"`
@@ -175,7 +177,9 @@ func (m *Configuration) saveConfiguration(tx *sqlx.Tx) error {
 			tires_wear_rate,
 			allowed_tires_out,
 			max_ballast,
+			start_rule,
 			disable_gas_cut_penality,
+			time_of_day_mult,
 			result_screen_time,
 			dynamic_track,
 			track_condition,
@@ -239,7 +243,9 @@ func (m *Configuration) saveConfiguration(tx *sqlx.Tx) error {
 			:tires_wear_rate,
 			:allowed_tires_out,
 			:max_ballast,
+			:start_rule,
 			:disable_gas_cut_penality,
+			:time_of_day_mult,
 			:result_screen_time,
 			:dynamic_track,
 			:track_condition,
@@ -319,7 +325,9 @@ func (m *Configuration) saveConfiguration(tx *sqlx.Tx) error {
 		tires_wear_rate = :tires_wear_rate,
 		allowed_tires_out = :allowed_tires_out,
 		max_ballast = :max_ballast,
+		start_rule = :start_rule,
 		disable_gas_cut_penality = :disable_gas_cut_penality,
+		time_of_day_mult = :time_of_day_mult,
 		result_screen_time = :result_screen_time,
 		dynamic_track = :dynamic_track,
 		track_condition = :track_condition,


### PR DESCRIPTION
Resolves #6 

So, would be great to get some testers and feedback, I had to implement some more settings to get the same config values when importing and then downloading a config.

Didn't find a way to handle the file inputs via the `v-model` approach, only got `@change` to work which I also found while searching for a solution.

Unknown track/cars are ignored and not added, but displayed in an alert at the moment to make the user aware of missing content.

This is entirely done in the client, nothing is uploaded/persisted until you click 'Save'.